### PR TITLE
Switched readme to correct license

### DIFF
--- a/.README.j2
+++ b/.README.j2
@@ -66,7 +66,7 @@ on the correct GitHub repository matching the add-on.
 
 MIT License
 
-Copyright (c) 2018-2021 Franck Nijhof
+Copyright (c) 2020 einschmidt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I noticed the README of this repo had the wrong license. Seemed like it was missed as part of a copy and paste since it still said Franck Nijhof.

The main reason I noticed was because I was combing through your repo to learn how you did all the workflows stuff to help me set up my own. I figured the least I could do was push a fix for this haha